### PR TITLE
Add gitignore for credentials and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python cache and compiled files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+.env/
+.venv/
+
+# Credential files
+*.json
+
+# Playwright browser data
+.playwright/
+playwright/
+.cache/
+ms-playwright/
+
+# Misc temporary files
+*.log
+*.tmp
+*.bak
+
+# Editor directories
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- ignore common Python caches and compiled files
- ignore virtual environment folders
- ignore credential files and temporary artifacts
- ignore Playwright browser data

## Testing
- `python -m py_compile scraper.py api.py OLD/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686c551856e8832992902d1cc62a9079