### PR TITLE
Add .gitignore for credentials and runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,26 @@
-caster-scraper*.json
+# Ignore credential files
+*.json
+
+# Ignore Python virtual environments
+venv/
+.venv/
+env/
+.env/
+ENV/
+
+# Ignore Playwright browser downloads
+playwright/
+.playwright/
+ms-playwright/
+
+# Ignore common Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+
+# Ignore editor settings
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- expand `.gitignore` to cover credential files, Python virtual environments, Playwright downloads, and other build artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c5c10349c83299b4275427afda697