### PR TITLE
Update README with usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
 # scraper
 
-Set the path to your Google service account credential JSON via the
-`GOOGLE_APPLICATION_CREDENTIALS` environment variable before running
-`scraper.py`.
+This project scrapes vendor product prices using Playwright and logs the results
+in Google Sheets.
+
+## Installation
+
+1. **Install Python requirements**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. **Install Playwright browsers** (required once per machine)
+   ```bash
+   playwright install
+   ```
+
+## Configuration
+
+Export the path to your Google service account credentials so the Google Sheets
+API can authenticate:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+```
+
+## Running the scraper
+
+Execute the scraper directly to update the sheet:
+
+```bash
+python3 scraper.py
+```
+
+Alternatively, start the Flask API and trigger a run with a POST request:
+
+```bash
+# Start the API server
+python3 api.py
+
+# In another terminal
+curl -X POST http://localhost:5050/scrape
+```
+
+## SSL troubleshooting
+
+If you encounter `SSL: CERTIFICATE_VERIFY_FAILED` errors when connecting to
+Google Sheets, your system certificates may be outdated. Updating the
+`certifi` package often resolves this:
+
+```bash
+pip install --upgrade certifi
+```
+
+On Linux ensure the `ca-certificates` package is installed. On macOS you can run
+`Install Certificates.command` from your Python installation.


### PR DESCRIPTION
## Summary
- add environment variable setup and usage instructions
- document dependency installation and Playwright browser install
- show how to run the scraper directly or via the Flask API
- note how to resolve SSL issues when connecting to Google Sheets

## Testing
- `python3 -m py_compile scraper.py api.py`

------
https://chatgpt.com/codex/tasks/task_e_686c5d187fe48329959372d9d2e280b4