### PR TITLE
Use GOOGLE_APPLICATION_CREDENTIALS env var

### DIFF
--- a/OLD/scraper-OG.py
+++ b/OLD/scraper-OG.py
@@ -1,5 +1,6 @@
 import datetime
 import asyncio
+import os
 import re
 from urllib.parse import urlparse
 from google.oauth2 import service_account
@@ -11,7 +12,6 @@ SPREADSHEET_ID = '1UmYEGz8jibtvNUkq5X5HbG3lCdZTfQ4Blooq9bwDZwc'
 LINKS_TAB = 'Caster Links'
 ERROR_TAB = 'Error Log'
 START_ROW = 2
-CREDENTIALS_FILE = 'caster-scraper-a25d671c35f0.json'
 HEADLESS = True  # Set to False for visual debugging
 
 # === VENDOR DEFAULT SELECTORS ===
@@ -26,7 +26,7 @@ VENDOR_SELECTOR_MAP = {
 # === GOOGLE SHEETS FUNCTIONS ===
 def get_sheets_service():
     creds = service_account.Credentials.from_service_account_file(
-        CREDENTIALS_FILE,
+        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
         scopes=['https://www.googleapis.com/auth/spreadsheets']
     )
     return build('sheets', 'v4', credentials=creds)


### PR DESCRIPTION
## Summary
- replace the hard-coded `CREDENTIALS_FILE` in `scraper-OG.py`
- fetch the path from the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
- import `os` accordingly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c5ef06e548329982d24f653d4272f