### PR TITLE
Move legacy scraper and add credentials

### DIFF
--- a/GOOGLE_APPLICATION_CREDENTIALS
+++ b/GOOGLE_APPLICATION_CREDENTIALS
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "caster-scraper",
+  "private_key_id": "a25d671c35f0be7337240f59d795d7e99cc29dd7",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCk9JNeTb5ru96L\nrOsdSs1cSmdihQq5jwOJDHhzKo3nl24sPYQlh8V9qAOiQRjZe2rHP/KPitcSEUGD\ndyVlva6d5c4xOshgBk8vo/TlQ0PInnCCxLJX7IvDUefM5eC0IVO7HP6kAFnV4eaW\nbZ3RRqOHNQYz/vpr9jgYGrSFcjlMlu6cmgzLLEaa+fe2HyZKSl/FH3wVZsSJ0t3G\nsfgSQN605MC53fgTznht3BRLsZAgGbMUvnCoC/FoFiccajQYXKdSkr+2P0R53W5u\n3FwMOfuBXWX3zn2bsmON/X212DyTF3CI2U+ax4BMQSgwMCsw30fLVK1Ez2+nA1KF\nL84pF2PDAgMBAAECggEAPc2e613QgxfkFUwH2TU+BR6hZqG3N3fUWMRR2sBuY39y\nmWPA/7jDb0WEewXN1CowAxA8Brj7xLqvY5y/58MuSd2gqARAr+2dPJm+9ykBHAj0\n2aHtuhCX+unUognc61BzSS9fXr386qxVUzYlw5OmUFG3DcMyO0IImUtkKH1353Ao\n93OQDbZrvableneBTw5my6WGfrLnKWK+0ZOKnB7SkLUIf7Ra/k8/aJrx5sUo/u2Z\nRnQ1vRWiigO4m89HOE7cvy0/iwPOFRBymWvuKEpKZKyUtt71OA8DJzo4WUdMi+8k\n3fWg71sxuAvzj/HyvVrWAGSwQ8BJGNXryhfuSI9khQKBgQDdFJ1eDy+5wwoctrVp\nJmIvCxNtntDawbIhwoytUqDRf8oQGB8AwUn6dF6ZuoB6dLj/y7YTEe022pOlk0p8\n7iFhu/8PgpJmvxGZp/G8761xy/3EIQQfW28BLrokvNXIOVmCMaoCo5oEg+nWz0/O\nuWL5EWK47SNMZIKo/jbRL0a1LwKBgQC/Aoq33UwUHLQ5S5ArrdUviFFlnYGRmPEU\nzIE0K3hifsruOD0PCLinvecw5B4ouL4bqZoIXOpBI0Cudxql83rKVYkileybvwiz\nTm+PVxh0jhA7BTmkQ+Y/nYGgDO6Fr6tVX1EiKEwjx/1zoNKnkioUsauYKdsTgqb7\nG98U1dl9rQKBgDrrVY1NytBdFILWhr6BRkV3VDQw0USbvpeUu90tWkK7JeToKMsQ\nuGCRRuz9cWQxW2SArAOlEW0/D35fJMjqxebALZe6mr3bShuDUL+juLvNO9JbYjfh\nLFJKW72Svf7gmeRCzCZr544wgc+H7KMRcTkj0wWp3XBskQ3swjs5uERtAoGAMut7\njX56LJZmWSvSuEI0JeLCSEOP6f+KrU/DVeQMyL0iXhUx+dMKXvVaL4dwnsx5Kaix\n/m6+qDS8poXr3bel0VCyKT0sgWyQ5jQPu3etdkz0+Lbw4eCT/fuANemcoJjvJOgv\nGdsCSTukTnHeFnv5qeCfbQYjd/UJjMGmW8iSnVUCgYEAwMnsvlVyKRY121QH/wDH\nEvcbRGQkukSia4wmYIceAm52hiVPQNEP+PWBofH5+25REyjWSWbQlGKHKTJeGc1H\nZ3uh0MFHl7dj7R4Wvbh4lllMUwZlBtcjekWrbyglFI36uZJZTZD8OwI4jPsw0SsL\nwQ8E6hofsP+XgZ7hqi+Cf/8=\n-----END PRIVATE KEY-----\n",
+  "client_email": "caster-scraper@caster-scraper.iam.gserviceaccount.com",
+  "client_id": "110145985654310739399",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/caster-scraper%40caster-scraper.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ in Google Sheets.
 
 ## Configuration
 
-Export the path to your Google service account credentials so the Google Sheets
-API can authenticate:
+The repository includes a service account file named `GOOGLE_APPLICATION_CREDENTIALS`.
+Export its path so the Google Sheets API can authenticate:
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/GOOGLE_APPLICATION_CREDENTIALS
 ```
 
 ## Running the scraper
 
-Execute the scraper directly to update the sheet:
+Execute the scraper directly to update the sheet using the legacy script now named `scraper_new.py`:
 
 ```bash
-python3 scraper.py
+python3 scraper_new.py
 ```
 
 Alternatively, start the Flask API and trigger a run with a POST request:

--- a/scraper_new.py
+++ b/scraper_new.py
@@ -1,0 +1,220 @@
+import datetime
+import asyncio
+import os
+import re
+from urllib.parse import urlparse
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError
+
+# === CONFIG ===
+SPREADSHEET_ID = '1UmYEGz8jibtvNUkq5X5HbG3lCdZTfQ4Blooq9bwDZwc'
+LINKS_TAB = 'Caster Links'
+ERROR_TAB = 'Error Log'
+START_ROW = 2
+HEADLESS = True  # Set to False for visual debugging
+
+# === VENDOR DEFAULT SELECTORS ===
+VENDOR_SELECTOR_MAP = {
+    'Harbor Freight': '#dy-pdp-price-label',
+    'Menards': '.full-price-discount-edlp',
+    'CasterCity.com': '.woocommerce-Price-amount.amount',
+    'MSC Direct': '#totalPriceId',
+    'Grainger': 'div[data-testid^="pricing-component-"]',
+}
+
+# === GOOGLE SHEETS FUNCTIONS ===
+def get_sheets_service():
+    service_account_path = os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        os.path.join(os.path.dirname(__file__), "GOOGLE_APPLICATION_CREDENTIALS"),
+    )
+    creds = service_account.Credentials.from_service_account_file(
+        service_account_path,
+        scopes=['https://www.googleapis.com/auth/spreadsheets']
+    )
+    return build('sheets', 'v4', credentials=creds)
+
+def get_links_with_selectors(service):
+    range_name = f"{LINKS_TAB}!C{START_ROW}:E"
+    result = service.spreadsheets().values().get(
+        spreadsheetId=SPREADSHEET_ID, range=range_name).execute()
+    return result.get('values', [])
+
+def get_next_col_letter(service):
+    result = service.spreadsheets().values().get(
+        spreadsheetId=SPREADSHEET_ID, range=f"{LINKS_TAB}!1:1").execute()
+    headers = result.get('values', [[]])[0]
+    next_col = len(headers) + 1
+    result_col = ""
+    while next_col > 0:
+        next_col, remainder = divmod(next_col - 1, 26)
+        result_col = chr(65 + remainder) + result_col
+    return result_col
+
+def write_prices(service, col_letter, prices):
+    service.spreadsheets().values().update(
+        spreadsheetId=SPREADSHEET_ID,
+        range=f"{LINKS_TAB}!{col_letter}{START_ROW}",
+        valueInputOption="RAW",
+        body={"values": prices}
+    ).execute()
+
+def write_date_header(service, col_letter):
+    today = datetime.date.today().strftime("Price %-m/%-d")
+    service.spreadsheets().values().update(
+        spreadsheetId=SPREADSHEET_ID,
+        range=f"{LINKS_TAB}!{col_letter}1",
+        valueInputOption="RAW",
+        body={"values": [[today]]}
+    ).execute()
+
+def log_errors(service, errors):
+    if not errors:
+        return
+    today = datetime.datetime.now().isoformat()
+    values = [[today, url, selector, error] for url, selector, error in errors]
+    service.spreadsheets().values().append(
+        spreadsheetId=SPREADSHEET_ID,
+        range=f"{ERROR_TAB}!A1",
+        valueInputOption="USER_ENTERED",
+        insertDataOption="INSERT_ROWS",
+        body={"values": values}
+    ).execute()
+
+# === SCRAPING HELPERS ===
+def extract_price(text):
+    matches = re.findall(r"\$\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})", text)
+    return matches[0] if matches else None
+
+def guess_vendor_from_url(url):
+    host = urlparse(url).netloc.lower()
+    if 'harborfreight' in host:
+        return 'Harbor Freight'
+    if 'menards' in host:
+        return 'Menards'
+    if 'castercity' in host:
+        return 'CasterCity.com'
+    if 'mscdirect' in host:
+        return 'MSC Direct'
+    if 'grainger' in host:
+        return 'Grainger'
+    return None
+
+async def enhanced_semantic_price_scan(page):
+    selector_patterns = [
+        '[class*="price"]',
+        '[id*="price"]',
+        '[class*="amount"]',
+        '[itemprop="price"]',
+        'meta[property="product:price:amount"]'
+    ]
+    for selector in selector_patterns:
+        try:
+            elements = await page.query_selector_all(selector)
+            for element in elements:
+                try:
+                    if "meta" in selector:
+                        content = await element.get_attribute("content")
+                        price = extract_price(content or "")
+                    else:
+                        text = await element.inner_text()
+                        price = extract_price(text or "")
+                    if price:
+                        return price
+                except Exception:
+                    continue
+        except Exception:
+            continue
+    return None
+
+async def fetch_price_from_page(page, url, selector=None):
+    try:
+        if "mcmaster.com" in url:
+            return "Login required – skipping"
+
+        await page.goto(url, timeout=20000)
+        await page.wait_for_timeout(3000)
+
+        # Tier 1: Specific selector
+        if selector:
+            try:
+                await page.wait_for_selector(selector, timeout=6000)
+                element = await page.query_selector(selector)
+                if element:
+                    text = await element.inner_text()
+                    price = extract_price(text)
+                    return price if price else "No price found in selector"
+                else:
+                    return "Selector not found on page"
+            except Exception as sel_error:
+                return f"Selector error: {sel_error}"
+
+        # Tier 2: Semantic fallback
+        price = await enhanced_semantic_price_scan(page)
+        if price:
+            return price
+
+        # Tier 3: Raw page content scan
+        content = await page.content()
+        return extract_price(content) or "No price found in fuzzy scan"
+
+    except PlaywrightTimeoutError:
+        return "Timeout"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+async def scrape_all(rows):
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=HEADLESS)
+        page = await browser.new_page()
+
+        results = []
+        errors = []
+
+        for idx, row in enumerate(rows):
+            url = row[0].strip() if len(row) > 0 else ""
+            manual_selector = row[1].strip() if len(row) > 1 else ""
+            vendor_override = row[2].strip() if len(row) > 2 else ""
+
+            if not url:
+                results.append([""])
+                continue
+
+            selector = None
+            if manual_selector:
+                selector = manual_selector
+            elif vendor_override in VENDOR_SELECTOR_MAP:
+                selector = VENDOR_SELECTOR_MAP[vendor_override]
+            else:
+                guessed = guess_vendor_from_url(url)
+                selector = VENDOR_SELECTOR_MAP.get(guessed)
+
+            print(f"Scraping: {url} | Using selector: {selector or 'semantic/fuzzy'}")
+            result = await fetch_price_from_page(page, url, selector)
+
+            if result and result.startswith("$"):
+                results.append([result])
+            else:
+                results.append([""])
+                errors.append((url, selector or "semantic/fuzzy", result))
+
+        await browser.close()
+        return results, errors
+
+# === MAIN ===
+def main():
+    print("🔁 Starting scraper...")
+    service = get_sheets_service()
+    links = get_links_with_selectors(service)
+    col_letter = get_next_col_letter(service)
+
+    prices, errors = asyncio.run(scrape_all(links))
+
+    write_prices(service, col_letter, prices)
+    write_date_header(service, col_letter)
+    log_errors(service, errors)
+    print("✅ Scraping complete.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add legacy `scraper-OG.py` script to repo root as **scraper_new.py**
- include `GOOGLE_APPLICATION_CREDENTIALS` service account file in repo
- default scraper to use this credentials file if `GOOGLE_APPLICATION_CREDENTIALS` env var is not set
- document new file path and updated run instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c61d0181483298e2009e057b094b8